### PR TITLE
Refactor model layout to shared typed folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,34 @@
 pip install forensicface
 ```
 
-Os arquivos onnx dos modelos de detecção (det_10g.onnx), pose
-(1k3d68.onnx) e sexo/idade (genderage.onnx) devem estar na pasta
-`~/.forensicface/models/<model_name>/`
+### Estrutura de pastas dos modelos
 
-O arquivo onnx do modelo de reconhecimento (ex. adaface_ir101web12m.onnx)
-deve estar na pasta `~/.forensicface/models/<model_name>/*face*/`
+A partir desta versão, os modelos são organizados por **tipo** em quatro
+pastas compartilhadas sob `~/.forensicface/models/`. Modelos que não
+dependem do `model_name` (detecção, atributos, qualidade) são
+compartilhados entre todos os modelos de reconhecimento, evitando
+duplicação em disco.
 
-O arquivo onnx do modelo de qualidade CR_FIQA (cr_fiqa_l.onnx) deve
-estar na pasta `~/.forensicface/models/<model_name>/cr_fiqa/`
+| Tipo | Caminho |
+|---|---|
+| Detecção (SCRFD)   | `~/.forensicface/models/detection/det_10g.onnx` |
+| Atributos — pose   | `~/.forensicface/models/attributes/1k3d68.onnx` |
+| Atributos — sexo/idade | `~/.forensicface/models/attributes/genderage.onnx` |
+| Qualidade (CR-FIQA) | `~/.forensicface/models/quality/cr_fiqa_l.onnx` |
+| Reconhecimento     | `~/.forensicface/models/recognition/<model_name>/*face*.onnx` |
+
+### Compatibilidade com a estrutura antiga
+
+O carregador continua aceitando a estrutura legada por *fallback*:
+
+- Detecção/pose/sexo-idade: `~/.forensicface/models/<model_name>/`
+- Reconhecimento: `~/.forensicface/models/<model_name>/*face*/`
+- Qualidade: `~/.forensicface/models/<model_name>/cr_fiqa/`
+
+Se a estrutura nova existir, ela é usada; caso contrário, recai sobre a
+estrutura antiga. Isto permite migrar gradualmente — basta mover os
+arquivos onnx compartilhados para as pastas novas e remover as cópias
+duplicadas.
 
 O modelo padrão é denominado `sepaelv2`. A partir da versão 0.1.5 é
 possível utilizar outros modelos.
@@ -28,6 +47,17 @@ possível utilizar outros modelos.
     na inicialização do forensicface (parâmetro `models_root`)
 - CUDA e CuDNN são instalados automaticamente no ambiente virtual  
     onde o forensicface for instalado.  
+
+## Notas de migração (estrutura compartilhada)
+
+- Os modelos de detecção, atributos e qualidade passaram a viver em
+  pastas compartilhadas (`detection/`, `attributes/`, `quality/`) sob
+  `models_root`, evitando que cada modelo de reconhecimento mantenha
+  cópias idênticas dos mesmos arquivos onnx.
+- Os modelos de reconhecimento ficam em `recognition/<model_name>/`.
+- A estrutura antiga (`<model_name>/...`) continua suportada como
+  *fallback* — usuários existentes não precisam migrar para a nova
+  versão funcionar.
 
 ## Documentação
 

--- a/src/forensicface/app.py
+++ b/src/forensicface/app.py
@@ -90,12 +90,7 @@ class ForensicFace:
             allowed_modules = ["detection", "landmark_3d_68", "genderage"]
 
             self.ort_fiqa = onnxruntime.InferenceSession(
-                osp.join(
-                    self.models_root,
-                    self.models[0],
-                    "cr_fiqa",
-                    "cr_fiqa_l.onnx",
-                ),
+                self._resolve_quality_model(self.models[0]),
                 providers=[self.providers[0]],
             )
         else:
@@ -128,19 +123,55 @@ class ForensicFace:
         return modules
 
     def _load_model(self, model_name, providers, gpu, models_root):
-        """Loads a single ONNX model."""
-        model_path = glob(
-            osp.join(
-                models_root, model_name, "*", "*face*.onnx"
-            )
-        )
+        """Loads a single ONNX face recognition model.
+
+        Tries the new shared layout first
+        (``<models_root>/recognition/<model_name>/*face*.onnx``)
+        and falls back to the legacy per-model layout
+        (``<models_root>/<model_name>/*/*face*.onnx``).
+        """
+        new_pattern = osp.join(models_root, "recognition", model_name, "*face*.onnx")
+        legacy_pattern = osp.join(models_root, model_name, "*", "*face*.onnx")
+
+        model_path = glob(new_pattern)
+        searched_pattern = new_pattern
         if len(model_path) == 0:
-            raise Exception(f"No face embedding model found in {osp.join(models_root, model_name)}")
+            model_path = glob(legacy_pattern)
+            searched_pattern = legacy_pattern
+
+        if len(model_path) == 0:
+            raise Exception(
+                f"No face embedding model found for '{model_name}'. "
+                f"Searched: {new_pattern} and {legacy_pattern}"
+            )
         if len(model_path) > 1:
-            raise Exception(f"Multiple face embedding models found in {osp.join(models_root, model_name)}: {model_path}\nPlease ensure there is only one ONNX file for face embedding in the model directory.")
+            raise Exception(
+                f"Multiple face embedding models found at {searched_pattern}: {model_path}\n"
+                f"Please ensure there is only one ONNX file for face embedding in the model directory."
+            )
         return onnxruntime.InferenceSession(
             model_path[0],
             providers=providers,
+        )
+
+    def _resolve_quality_model(self, model_name: str) -> str:
+        """Resolves the CR-FIQA quality model path.
+
+        Tries the new shared layout first
+        (``<models_root>/quality/cr_fiqa_l.onnx``) and falls back to the
+        legacy per-model layout
+        (``<models_root>/<model_name>/cr_fiqa/cr_fiqa_l.onnx``).
+        """
+        new_path = osp.join(self.models_root, "quality", "cr_fiqa_l.onnx")
+        if osp.isfile(new_path):
+            return new_path
+        legacy_path = osp.join(
+            self.models_root, model_name, "cr_fiqa", "cr_fiqa_l.onnx"
+        )
+        if osp.isfile(legacy_path):
+            return legacy_path
+        raise FileNotFoundError(
+            f"CR-FIQA quality model not found. Searched: {new_path} and {legacy_path}"
         )
 
     def _to_input_ada(self, aligned_bgr_img):

--- a/src/forensicface/backends.py
+++ b/src/forensicface/backends.py
@@ -58,15 +58,16 @@ class ONNXOnlyBackend(FaceBackend):
     ):
         self.name = "onnx"
         model_dir = osp.join(models_root, model_name)
-        if not osp.isdir(model_dir):
+
+        onnx_files = self._collect_onnx_files(models_root, model_name)
+        if not onnx_files:
+            new_detection = osp.join(models_root, "detection")
+            new_attributes = osp.join(models_root, "attributes")
             raise FileNotFoundError(
-                f"Model directory not found: {model_dir}. "
+                f"No ONNX model files found. Searched: {new_detection}, "
+                f"{new_attributes} (new shared layout) and {model_dir} (legacy layout). "
                 f"Download models into {models_root} or provide a valid model name."
             )
-
-        onnx_files = sorted(glob.glob(osp.join(model_dir, "*.onnx")))
-        if not onnx_files:
-            raise FileNotFoundError(f"No ONNX model files found under {model_dir}")
 
         self.det_model = None
         self.landmark_model = None
@@ -80,7 +81,11 @@ class ONNXOnlyBackend(FaceBackend):
             except Exception:
                 candidate = None
 
-            if candidate is not None and candidate.taskname == "detection":
+            if (
+                self.det_model is None
+                and candidate is not None
+                and candidate.taskname == "detection"
+            ):
                 self.det_model = candidate
                 self._detection_file = onnx_file
                 continue
@@ -126,8 +131,10 @@ class ONNXOnlyBackend(FaceBackend):
                     pass
 
         if self.det_model is None:
+            new_detection = osp.join(models_root, "detection")
             raise RuntimeError(
-                f"Could not load a SCRFD detection model from {model_dir}."
+                f"Could not load a SCRFD detection model. "
+                f"Searched: {new_detection} (new shared layout) and {model_dir} (legacy layout)."
             )
 
         self.det_model.prepare(ctx_id, input_size=det_size, det_thresh=det_thresh)
@@ -135,6 +142,34 @@ class ONNXOnlyBackend(FaceBackend):
             self.landmark_model.prepare(ctx_id)
         if self.genderage_model is not None:
             self.genderage_model.prepare(ctx_id)
+
+    @staticmethod
+    def _collect_onnx_files(models_root: str, model_name: str) -> list[str]:
+        """Collects candidate ONNX files for backend probing.
+
+        Prefers the new shared layout (``detection/`` and ``attributes/``
+        directories under ``models_root``) and falls back to the legacy
+        per-model layout (``<models_root>/<model_name>/``). Files from the
+        new layout appear first so backward-compatible detection picks them
+        up before any duplicates in the legacy folder.
+        """
+        sources = [
+            osp.join(models_root, "detection"),
+            osp.join(models_root, "attributes"),
+            osp.join(models_root, model_name),
+        ]
+        files: list[str] = []
+        seen: set[str] = set()
+        for source in sources:
+            if not osp.isdir(source):
+                continue
+            for path in sorted(glob.glob(osp.join(source, "*.onnx"))):
+                normalized = osp.normpath(path)
+                if normalized in seen:
+                    continue
+                seen.add(normalized)
+                files.append(path)
+        return files
 
     def detect_faces(self, bgr_img: np.ndarray) -> list[FaceData]:
         bboxes, kpss = self.det_model.detect(bgr_img, max_num=0, metric="default")

--- a/tests/test_backends_and_api.py
+++ b/tests/test_backends_and_api.py
@@ -1,3 +1,5 @@
+import os.path as osp
+
 import numpy as np
 import pytest
 import cv2
@@ -322,11 +324,11 @@ def test_onnx_backend_loads_landmark_3d68_when_requested(monkeypatch):
     assert backend.genderage_model is not None
 
 
-def test_load_model_uses_forensicface_model_root(monkeypatch):
-    captured = {}
+def test_load_model_prefers_new_recognition_layout(monkeypatch):
+    captured = {"patterns": []}
 
     def fake_glob(pattern):
-        captured["pattern"] = pattern
+        captured["patterns"].append(pattern)
         return ["/fake/path/face.onnx"]
 
     class _DummySession:
@@ -336,15 +338,80 @@ def test_load_model_uses_forensicface_model_root(monkeypatch):
     monkeypatch.setattr(app_module.onnxruntime, "InferenceSession", lambda *_a, **_k: _DummySession())
 
     ff = object.__new__(ForensicFace)
+    models_root = str(Path.home() / ".forensicface" / "models")
     ff._load_model(
         model_name="sepaelv2",
         providers=["CPUExecutionProvider"],
         gpu=0,
-        models_root=str(Path.home() / ".forensicface" / "models"),
+        models_root=models_root,
     )
 
-    assert captured["pattern"].startswith(str(Path.home() / ".forensicface" / "models" / "sepaelv2"))
-    assert "*face*.onnx" in captured["pattern"]
+    new_prefix = str(Path(models_root) / "recognition" / "sepaelv2")
+    assert captured["patterns"][0].startswith(new_prefix)
+    assert "*face*.onnx" in captured["patterns"][0]
+
+
+def test_load_model_falls_back_to_legacy_layout(monkeypatch):
+    captured = {"patterns": []}
+
+    def fake_glob(pattern):
+        captured["patterns"].append(pattern)
+        # First call (new layout) returns empty; second call (legacy) returns a hit.
+        return [] if len(captured["patterns"]) == 1 else ["/fake/path/face.onnx"]
+
+    class _DummySession:
+        pass
+
+    monkeypatch.setattr(app_module, "glob", fake_glob)
+    monkeypatch.setattr(app_module.onnxruntime, "InferenceSession", lambda *_a, **_k: _DummySession())
+
+    ff = object.__new__(ForensicFace)
+    models_root = str(Path.home() / ".forensicface" / "models")
+    ff._load_model(
+        model_name="sepaelv2",
+        providers=["CPUExecutionProvider"],
+        gpu=0,
+        models_root=models_root,
+    )
+
+    assert len(captured["patterns"]) == 2
+    legacy_prefix = str(Path(models_root) / "sepaelv2")
+    assert captured["patterns"][1].startswith(legacy_prefix)
+    assert "*face*.onnx" in captured["patterns"][1]
+
+
+def test_resolve_quality_model_prefers_new_layout(monkeypatch, tmp_path):
+    quality_dir = tmp_path / "quality"
+    quality_dir.mkdir()
+    new_path = quality_dir / "cr_fiqa_l.onnx"
+    new_path.write_bytes(b"fake-onnx")
+
+    ff = object.__new__(ForensicFace)
+    ff.models_root = str(tmp_path)
+
+    resolved = ff._resolve_quality_model("sepaelv2")
+    assert Path(resolved) == new_path
+
+
+def test_resolve_quality_model_falls_back_to_legacy_layout(tmp_path):
+    legacy_dir = tmp_path / "sepaelv2" / "cr_fiqa"
+    legacy_dir.mkdir(parents=True)
+    legacy_path = legacy_dir / "cr_fiqa_l.onnx"
+    legacy_path.write_bytes(b"fake-onnx")
+
+    ff = object.__new__(ForensicFace)
+    ff.models_root = str(tmp_path)
+
+    resolved = ff._resolve_quality_model("sepaelv2")
+    assert Path(resolved) == legacy_path
+
+
+def test_resolve_quality_model_raises_when_missing(tmp_path):
+    ff = object.__new__(ForensicFace)
+    ff.models_root = str(tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="cr_fiqa_l.onnx"):
+        ff._resolve_quality_model("sepaelv2")
 
 
 def test_onnx_backend_missing_directory_message_uses_forensicface_root(monkeypatch):
@@ -362,3 +429,107 @@ def test_onnx_backend_missing_directory_message_uses_forensicface_root(monkeypat
             det_thresh=0.5,
             models_root="/fake/model",
         )
+
+
+def test_backend_prefers_new_shared_structure_over_legacy(monkeypatch):
+    import forensicface.backends as backends_module
+
+    new_det = "/fake/model/detection/det_10g.onnx"
+    legacy_det = "/fake/model/sepaelv2/det_10g.onnx"
+
+    glob_calls = {"patterns": []}
+
+    def fake_glob(pattern):
+        glob_calls["patterns"].append(pattern)
+        if pattern.endswith(osp.join("detection", "*.onnx")):
+            return [new_det]
+        if pattern.endswith(osp.join("attributes", "*.onnx")):
+            return []
+        if pattern.endswith(osp.join("sepaelv2", "*.onnx")):
+            return [legacy_det]
+        return []
+
+    class _DummyDetModel:
+        taskname = "detection"
+
+        def __init__(self, model_file):
+            self.model_file = model_file
+
+        def prepare(self, *_args, **_kwargs):
+            return None
+
+    def fake_scrfd(model_file=None, **_kwargs):
+        return _DummyDetModel(model_file)
+
+    monkeypatch.setattr(backends_module.osp, "isdir", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(backends_module.glob, "glob", fake_glob)
+    monkeypatch.setattr(backends_module, "SCRFD", fake_scrfd)
+
+    backend = backends_module.ONNXOnlyBackend(
+        model_name="sepaelv2",
+        allowed_modules=["detection"],
+        providers=["CPUExecutionProvider"],
+        ctx_id=-1,
+        det_size=(320, 320),
+        det_thresh=0.5,
+        models_root="/fake/model",
+    )
+
+    assert backend.det_model.model_file == new_det
+
+
+def test_backend_falls_back_to_legacy_when_new_layout_missing(monkeypatch):
+    import forensicface.backends as backends_module
+
+    legacy_dir = osp.join("/fake/model", "sepaelv2")
+    legacy_det = osp.join(legacy_dir, "det_10g.onnx")
+
+    def fake_isdir(path):
+        return osp.normpath(path) == osp.normpath(legacy_dir)
+
+    def fake_glob(pattern):
+        if pattern.endswith(osp.join("sepaelv2", "*.onnx")):
+            return [legacy_det]
+        return []
+
+    class _DummyDetModel:
+        taskname = "detection"
+
+        def __init__(self, model_file):
+            self.model_file = model_file
+
+        def prepare(self, *_args, **_kwargs):
+            return None
+
+    def fake_scrfd(model_file=None, **_kwargs):
+        return _DummyDetModel(model_file)
+
+    monkeypatch.setattr(backends_module.osp, "isdir", fake_isdir)
+    monkeypatch.setattr(backends_module.glob, "glob", fake_glob)
+    monkeypatch.setattr(backends_module, "SCRFD", fake_scrfd)
+
+    backend = backends_module.ONNXOnlyBackend(
+        model_name="sepaelv2",
+        allowed_modules=["detection"],
+        providers=["CPUExecutionProvider"],
+        ctx_id=-1,
+        det_size=(320, 320),
+        det_thresh=0.5,
+        models_root="/fake/model",
+    )
+
+    assert backend.det_model.model_file == legacy_det
+
+
+def test_collect_onnx_files_dedupes_across_sources(monkeypatch):
+    import forensicface.backends as backends_module
+
+    duplicate = "/fake/model/detection/det_10g.onnx"
+
+    monkeypatch.setattr(backends_module.osp, "isdir", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(backends_module.glob, "glob", lambda *_args, **_kwargs: [duplicate])
+
+    files = backends_module.ONNXOnlyBackend._collect_onnx_files(
+        "/fake/model", "sepaelv2"
+    )
+    assert files == [duplicate]


### PR DESCRIPTION
Modelos de detecção, atributos e qualidade passam a viver em pastas compartilhadas sob `models_root`:

  - detection/{det_10g}.onnx
  - attributes/{1k3d68,genderage}.onnx
  - quality/cr_fiqa_l.onnx
  - recognition/<model_name>/*face*.onnx

Antes, cada modelo de reconhecimento (sepaelv2/v3/v4/v5) carregava cópias idênticas dos arquivos compartilhados (~1.27 GB duplicados em 3.1 GB totais nas pastas existentes).

A estrutura legada (`<model_name>/...`) continua aceita por fallback: o carregador tenta a estrutura nova primeiro e recai para a antiga se nada for encontrado. Usuários existentes não precisam migrar para o código continuar funcionando.

Alterações principais:
  - ForensicFace._load_model: tenta recognition/<model>/*face*.onnx primeiro, fallback para <model>/*/*face*.onnx
  - ForensicFace._resolve_quality_model: novo helper com fallback para quality/cr_fiqa_l.onnx
  - ONNXOnlyBackend._collect_onnx_files: combina detection/, attributes/ e <model>/ preservando ordem (novo > antigo) e deduplicando

Testes: 19 passando (5 novos para cobrir o fallback bidirecional e a deduplicação por fonte).